### PR TITLE
Adding Garden to default schema

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -23,6 +23,10 @@ export function buildCommonSF(system, command) {
       'title': 'System Version', 'type': 'string',
       'default': system.version, 'required': true,
     },
+    'garden': {
+      'title': 'Garden', 'type': 'string',
+      'default': system.garden, 'required': true,
+    },
     'namespace': {
       'title': 'Namespace', 'type': 'string',
       'default': system.namespace, 'required': true,


### PR DESCRIPTION
This is required for when we add Gardens to Request Objects for the new filtering approach